### PR TITLE
[BKY-4461] Add configurable FQDN

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Describe your changes
+
+## Related Jira cards
+
+## Notes for reviewers
+
+## Checklist before requesting a review
+If any of these checks are missing, please provide an explanation.
+
+- [ ] I have updated README files, if applicable.
+- [ ] I have run `make test`

--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,9 @@ run-socksproxy: socksproxy
 run-socksproxy-quiet: socksproxy
 	$(TARGETS)/socksproxy &> $(TARGETS)/socksproxy.log &
 
+test:
+	@echo "Test socksproxy..."
+	@go test -count=1 ./...
+
 clean:
 	rm -rf $(TARGETS)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # Socks Proxy
-A Socks5 server that, when used in conjunction with a [viproxy](https://github.com/blocky/viproxy), grants networking capabilities to a program running in a Nitro Server. The current iteration, however, is coded to only allow connections to [Let's Encrypt](https://letsencrypt.org/) for the purpose of getting self-signed certificates. If you wish to communicate with other services, you will have to update the `allowedAddrs` or `allowedFQDNs` variables.
+
+A Socks5 server that, when used in conjunction with a
+[viproxy](https://github.com/blocky/viproxy), grants networking capabilities to
+a program running in a Nitro Server.
+
+The current iteration, however, is coded
+to either just allow connections to [Let's Encrypt](https://letsencrypt.org/) for the
+purpose of getting self-signed certificates, or it allows all connections.
+
+## Usage
+
+The easy way to set up development is to run the server in verbose mode:
+
+    go run main.go --verbose
+
+This will start a socks5 proxy on the default port `:1080`.  From a different
+shell, you can use curl to make a request though the proxy with the following
+command:
+
+    curl --socks5-hostname localhost:1080 https://acme-v02.api.letsencrypt.org
+
+This command should succeed and return a website.
+
+Next, we can try to make a request that should be blocked:
+
+	curl --socks5-hostname localhost:1080 https://example.com
+
+This command should fail with some message such as:
+
+    curl: (97) Can't complete SOCKS5 connection to example.com. (2)
+
+Next, let's set up our proxy so that it allows all requests
+
+    go run main.go --verbose --fqdn-allow-all
+
+Now, try again, both `curl` requests should now succeed.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Socks Proxy
+# SOCKS Proxy
 
-A Socks5 server that, when used in conjunction with a
+A SOCKS5 server that, when used in conjunction with a
 [viproxy](https://github.com/blocky/viproxy), grants networking capabilities to
 a program running in a Nitro Server.
 
-The current iteration, however, is coded
-to either just allow connections to [Let's Encrypt](https://letsencrypt.org/) for the
-purpose of getting self-signed certificates, or it allows all connections.
+The current iteration, however, is coded to either just allow connections to
+[Let's Encrypt](https://letsencrypt.org/) for the purpose of getting
+self-signed certificates, or it allows all connections.
 
 ## Usage
 
@@ -14,7 +14,7 @@ The easy way to set up development is to run the server in verbose mode:
 
     go run main.go --verbose
 
-This will start a socks5 proxy on the default port `:1080`.  From a different
+This will start a SOCKS5 proxy on the default port `:1080`.  From a different
 shell, you can use curl to make a request though the proxy with the following
 command:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ a program running in a Nitro Server.
 
 The current iteration, however, is coded to either just allow connections to
 [Let's Encrypt](https://letsencrypt.org/) for the purpose of getting
-self-signed certificates, or it allows all connections.
+self-signed certificates, or it allows all outgoing HTTP connections.
 
 ## Usage
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,10 @@ const (
 
 type allowLetsEncrypt struct{}
 
-func (m allowLetsEncrypt) Allow(ctx context.Context, req *socks5.Request) (context.Context, bool) {
+func (m allowLetsEncrypt) Allow(
+	ctx context.Context,
+	req *socks5.Request,
+) (context.Context, bool) {
 	for _, fqdn := range []string{letsEncryptProd, letsEncryptStaging} {
 		if req.DestAddr.FQDN == fqdn {
 			return ctx, allowed
@@ -31,7 +34,10 @@ type logAll struct {
 	rules socks5.RuleSet
 }
 
-func (m logAll) Allow(ctx context.Context, req *socks5.Request) (context.Context, bool) {
+func (m logAll) Allow(
+	ctx context.Context,
+	req *socks5.Request,
+) (context.Context, bool) {
 	ctx, allowed := m.rules.Allow(ctx, req)
 
 	prefix := "Denying"

--- a/main.go
+++ b/main.go
@@ -3,81 +3,98 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
-	"net"
 
 	"github.com/armon/go-socks5"
 )
 
 const (
-	allowed = true
-	denied  = false
+	allowed            = true
+	denied             = false
+	letsEncryptProd    = "acme-v02.api.letsencrypt.org"
+	letsEncryptStaging = "acme-staging-v02.api.letsencrypt.org"
 )
 
-type myRule struct {
-	addrs []net.IP
-	fqdns []string
-}
+type allowLetsEncrypt struct{}
 
-func logConn(allowed bool, from, to *socks5.AddrSpec) {
-	var prefix string
-	if allowed {
-		prefix = "Allowing"
-	} else {
-		prefix = "Denying"
-	}
-	log.Printf("%s connection request from %s:%d (%s) to %s:%d (%s).",
-		prefix,
-		from.IP, from.Port, from.FQDN,
-		to.IP, to.Port, to.FQDN)
-}
-
-func (m myRule) Allow(ctx context.Context, req *socks5.Request) (context.Context, bool) {
-	for _, addr := range m.addrs {
-		if req.DestAddr.IP.Equal(addr) {
-			logConn(allowed, req.RemoteAddr, req.DestAddr)
-			return ctx, allowed
-		}
-	}
-	for _, fqdn := range m.fqdns {
+func (m allowLetsEncrypt) Allow(ctx context.Context, req *socks5.Request) (context.Context, bool) {
+	for _, fqdn := range []string{letsEncryptProd, letsEncryptStaging} {
 		if req.DestAddr.FQDN == fqdn {
-			logConn(allowed, req.RemoteAddr, req.DestAddr)
 			return ctx, allowed
 		}
 	}
-	logConn(denied, req.RemoteAddr, req.DestAddr)
 	return ctx, denied
 }
 
-func main() {
-	var addr string
-	// allowedAddrs represents the list of IP addresses that the SOCKS server
-	// allows connections to.  The list contains our Kafka cluster.
-	allowedAddrs := []net.IP{}
-	// allowedFQDNs represents the list of FQDNs that the SOCKS server allows
-	// connections to.  The list contains Let's Encrypt's domain names.
-	allowedFQDNs := []string{
-		"acme-v02.api.letsencrypt.org",
-		"acme-staging-v02.api.letsencrypt.org",
-	}
+type logAll struct {
+	rules socks5.RuleSet
+}
 
-	flag.StringVar(&addr, "addr", ":1080", "Address to listen on.")
+func (m logAll) Allow(ctx context.Context, req *socks5.Request) (context.Context, bool) {
+	ctx, allowed := m.rules.Allow(ctx, req)
+
+	prefix := "Denying"
+	if allowed {
+		prefix = "Allowing"
+	}
+	from := req.RemoteAddr
+	to := req.DestAddr
+	log.Printf("%s connection request from %s:%d (%s) to %s:%d (%s).",
+		prefix,
+		from.IP, from.Port, from.FQDN,
+		to.IP, to.Port, to.FQDN,
+	)
+
+	return ctx, allowed
+}
+
+type config struct {
+	addr         string
+	fqdnAllowAll bool
+	verbose      bool
+}
+
+func parseFlags() config {
+	c := config{}
+
+	flag.StringVar(&c.addr, "addr", ":1080", "Address to listen on.")
+	flag.BoolVar(&c.fqdnAllowAll, "fqdn-allow-all", false, "Allow all FQDNs")
+	flag.BoolVar(&c.verbose, "verbose", false, "log verbosely")
 	flag.Parse()
-	log.Printf("Starting SOCKSv5 server on %s.", addr)
 
-	conf := &socks5.Config{
-		Rules: myRule{
-			addrs: allowedAddrs,
-			fqdns: allowedFQDNs,
-		},
+	return c
+}
+
+func newServer(cfg config) (*socks5.Server, error) {
+	var rules socks5.RuleSet = allowLetsEncrypt{}
+	if cfg.fqdnAllowAll {
+		rules = socks5.PermitAll()
 	}
+
+	if cfg.verbose {
+		rules = logAll{rules}
+	}
+
+	conf := &socks5.Config{Rules: rules}
 	server, err := socks5.New(conf)
+	if err != nil {
+		return nil, fmt.Errorf("creating proxy server: %w", err)
+	}
+
+	return server, nil
+}
+
+func main() {
+	cfg := parseFlags()
+
+	server, err := newServer(cfg)
 	if err != nil {
 		panic(err)
 	}
 
-	// Create SOCKS5 proxy.
-	if err := server.ListenAndServe("tcp", addr); err != nil {
+	log.Printf("Starting SOCKSv5 server on %s.", cfg.addr)
+	if err := server.ListenAndServe("tcp", cfg.addr); err != nil {
 		panic(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -85,7 +85,7 @@ func newServer(cfg config) (*socks5.Server, error) {
 	socks5Cfg := &socks5.Config{Rules: rules}
 	server, err := socks5.New(socks5Cfg)
 	if err != nil {
-		return nil, fmt.Errorf("creating proxy server: %w", err)
+		return nil, fmt.Errorf("creating SOCKS5 server: %w", err)
 	}
 
 	return server, nil

--- a/main.go
+++ b/main.go
@@ -82,8 +82,8 @@ func newServer(cfg config) (*socks5.Server, error) {
 		rules = logAll{rules}
 	}
 
-	conf := &socks5.Config{Rules: rules}
-	server, err := socks5.New(conf)
+	socks5Cfg := &socks5.Config{Rules: rules}
+	server, err := socks5.New(socks5Cfg)
 	if err != nil {
 		return nil, fmt.Errorf("creating proxy server: %w", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -51,9 +51,10 @@ func TestStartServer(t *testing.T) {
 			tt.dst,
 		).Output()
 
-		if tt.success && err != nil {
+		switch {
+		case tt.success && err != nil:
 			t.Errorf("expected no error, got %v", err)
-		} else if !tt.success && err == nil {
+		case !tt.success && err == nil:
 			t.Errorf("expected error, got no error")
 		}
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os/exec"
+	"testing"
+)
+
+func TestStartServer(t *testing.T) {
+	other := "https://example.com"
+	letsEncrypt := fmt.Sprintf("https://%s", letsEncryptStaging)
+
+	for _, tt := range []struct {
+		allowAll bool
+		dst      string
+		success  bool
+	}{
+		{allowAll: false, dst: letsEncrypt, success: true},
+		{allowAll: false, dst: other, success: false},
+		{allowAll: true, dst: letsEncrypt, success: true},
+		{allowAll: true, dst: other, success: true},
+	} {
+		cfg := config{
+			addr:         ":1081",
+			verbose:      false,
+			fqdnAllowAll: tt.allowAll,
+		}
+
+		server, err := newServer(cfg)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		listener, err := net.Listen("tcp", cfg.addr)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		wait := make(chan struct{})
+		go func() {
+			// we don't care about the error here
+			_ = server.Serve(listener)
+			close(wait)
+		}()
+
+		_, err = exec.Command(
+			"curl",
+			"--socks5-hostname",
+			"localhost"+cfg.addr,
+			tt.dst,
+		).Output()
+
+		if tt.success && err != nil {
+			t.Errorf("expected no error, got %v", err)
+		} else if !tt.success && err == nil {
+			t.Errorf("expected error, got no error")
+		}
+
+		listener.Close()
+		<-wait
+	}
+}


### PR DESCRIPTION
In this PR, we add the `--fqdn-allow-all` flag to allows all connections though
the proxy.

A few other additions include:
- Add a `--verbose` flag to log verbosely (this does not, however change the
  logging supported in the socks5 library
- add comments in README.md to help users get started developing
- add some simple integration tests for the proxy
